### PR TITLE
Bump traceur version to 0.74

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/vojtajina/atscript-playground/issues"
   },
   "dependencies": {
-    "traceur": "^0.0.72",
+    "traceur": "^0.0.74",
     "requirejs": "^2.1.15"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds support for not dying on generics syntax, among other changes.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/atscript-playground/13)

<!-- Reviewable:end -->
